### PR TITLE
Change seaborn dependency to seaborn-base

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,7 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -6,3 +10,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - pandas_profiling = ydata_profiling.controller.console:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -35,7 +35,7 @@ requirements:
     - phik >=0.11.1,<0.13
     - requests >=2.24.0,<3
     - tqdm >=4.48.2,<5
-    - seaborn >=0.10.1,<0.13
+    - seaborn-base >=0.10.1,<0.13
     - multimethod >=1.4,<2
     - statsmodels >=0.13.2,<1
     - typeguard >=4.1.2,<5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - phik >=0.11.1,<0.13
     - requests >=2.24.0,<3
     - tqdm >=4.48.2,<5
-    - seaborn-base >=0.10.1,<0.13
+    - seaborn-base >0.10.1,<0.13
     - multimethod >=1.4,<2
     - statsmodels >=0.13.2,<1
     - typeguard >=4.1.2,<5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - phik >=0.11.1,<0.13
     - requests >=2.24.0,<3
     - tqdm >=4.48.2,<5
-    - seaborn-base >0.10.1,<0.13
+    - seaborn-base >=0.10.1,<0.13
     - multimethod >=1.4,<2
     - statsmodels >=0.13.2,<1
     - typeguard >=4.1.2,<5


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As for matplotlib, it's better to depend on seaborn-base (without statsmodel), especially when you depend on statsmodel explicitly. See https://github.com/conda-forge/seaborn-feedstock/blob/main/recipe/meta.yaml for definitions.

Also excluded seaborn 0.10.1, because [build 0](https://github.com/conda-forge/seaborn-feedstock/commit/776f0d85ddd99d0dceec3d8c8a45f26a481ad1cb) doesn't depend on seaborn-base and causes a conflict when installing both seaborn-base and ydata-profiling. _edit_: actually if it depends on seaborn-base, then there is no build 0 of this.