### PR TITLE
Convert ydata-profiling-feedstock to v1 feedstock

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Package license: MIT
 
 Summary: Generate profile report for pandas DataFrame
 
-Documentation: https://ydata-profiling.ydata.ai
+Documentation: https://ydata-profiling.ydata.ai/
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,5 @@ conda_forge_output_validation: true
 bot:
   automerge: true
   inspection: hint-all
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,6 +6,8 @@ conda_build:
 conda_forge_output_validation: true
 bot:
   automerge: true
-  inspection: hint-all
+  inspection: update-all
+  check_solvable: true
+  run_deps_from_wheel: true
 conda_install_tool: pixi
 conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "ydata-profiling-feedstock"
+version = "3.51.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/ydata-profiling-feedstock"
+authors = ["@conda-forge/ydata-profiling"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build ydata-profiling-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build ydata-profiling-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of ydata-profiling-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,8 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 schema_version: 1
 
 context:
   name: ydata-profiling
-  version: 4.17.0
+  version: "4.17.0"
 
 package:
   name: ${{ name|lower }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -62,6 +62,7 @@ tests:
   - python:
       imports:
         - ydata_profiling
+      pip_check: true
       python_version: ${{ python_min }}.*
   - requirements:
       run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,30 +1,34 @@
-{% set name = "ydata-profiling" %}
-{% set version = "4.17.0" %}
+schema_version: 1
+
+context:
+  name: ydata-profiling
+  version: 4.17.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ydata-profiling-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/ydata-profiling-${{ version }}.tar.gz
   sha256: 6ead76a9bffe170a6fcb6195248cd5110bdfc7971af9257c0e6716b4f1e65815
 
 build:
-  entry_points:
-    - ydata_profiling = ydata_profiling.controller.console:main
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - ydata_profiling = ydata_profiling.controller.console:main
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - setuptools >=72.0.0,<80.0.0
     - setuptools-scm >=8.0.0,<9.0.0
     - wheel >=0.38.4,<1.0.0
     - pip
   run:
-    - python >={{ python_min }},<3.14
+    - python >=${{ python_min }},<3.14
     - scipy >=1.4.1,<1.16
     - pandas >1.1,<3.0,!=1.4.0
     - matplotlib-base >=3.5,<=3.10
@@ -47,32 +51,31 @@ requirements:
     - dacite >=1.8
     - numba >=0.56.0,<=0.61
     - ipython <9.0
-  run_constrained:
+  run_constraints:
     - jupyter-client >=5.3.4
     - jupyter-core >=4.6.3
     - ipywidgets >=7.5.1
     - tangled-up-in-unicode ==0.2.0
 
-test:
-  imports:
-    - ydata_profiling
-  commands:
-# Disabling pip check -   ydata-profiling 0.0.dev0 has requirement wordcloud>=1.9.3, but you have wordcloud 0.0.0.
-    - pip check
-    # make sure the version reported by pip is correct
-    #- "pip show {{ name }} | grep -Fx 'Version: {{ version }}'"
-    - ydata_profiling --help
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - ydata_profiling
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - pip check
+      - ydata_profiling --help
 
 about:
-  home: https://github.com/ydataai/ydata-profiling
   summary: Generate profile report for pandas DataFrame
   license: MIT
-  license_family: MIT
   license_file: LICENSE
-  doc_url: https://ydata-profiling.ydata.ai
+  homepage: https://github.com/ydataai/ydata-profiling
+  documentation: https://ydata-profiling.ydata.ai
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts ydata-profiling-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.14.dev26+g9fab0e2b0](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
